### PR TITLE
Use plain text as default format for each attendee

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ const resolveDate = (d: { dateTime?: string; format?: string }) => {
 
 const resolveAttendees = (e: Event, s:string) => {
   const attendessListString = (e.attendees || [])
-    .map((attn) => (s || "[[NAME]]").replace("NAME", attn["displayName"] || attn["email"]))
+    .map((attn) => (s || "NAME").replace("NAME", attn["displayName"] || attn["email"]))
     .join(", ");
 
   return attendessListString;


### PR DESCRIPTION
Attendees can take a custom format, using `NAME` as a placeholder for the display name (when available) or their email address. The default now is `[[NAME]]`, which creates new page links every time (and new pages the first time). This changes the default to `NAME`, for the previous plain text format.

Fixes #2 