### PR TITLE
Replace attendee name as many times as it appears

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ const resolveDate = (d: { dateTime?: string; format?: string }) => {
 
 const resolveAttendees = (e: Event, s:string) => {
   const attendessListString = (e.attendees || [])
-    .map((attn) => (s || "NAME").replace("NAME", attn["displayName"] || attn["email"]))
+    .map((attn) => (s || "NAME").replace(/NAME/g, attn["displayName"] || attn["email"]))
     .join(", ");
 
   return attendessListString;


### PR DESCRIPTION
When formatting attendee names, replace the `NAME` placeholder as many times as it appears in the format string, rather than the current first time only.

Fixes #5 