### PR TITLE
Custom event formatter support

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -37,6 +37,16 @@ const resolveSummary = (e: Event) =>
   e.visibility === "private" ? "busy" : e.summary || "No Summary";
 
 export const formatEvent = (e: Event, format: string, includeLink: boolean): string => {
+function resolveDuration(e: Event) {
+  return (e.start?.dateTime && e.end?.dateTime
+      ? differenceInMinutes(
+        new Date(e.end.dateTime),
+        new Date(e.start.dateTime)
+      )
+      : 24 * 60
+  ).toString();
+}
+
   const summaryText = resolveSummary(e);
   const summary =
     includeLink && e.htmlLink
@@ -73,16 +83,7 @@ export const formatEvent = (e: Event, format: string, includeLink: boolean): str
           resolveDate({...e.end, format})
         )
         .replace(/{calendar}/, e.calendar)
-        .replace(
-          "{duration}",
-          (e.start?.dateTime && e.end?.dateTime
-              ? differenceInMinutes(
-                new Date(e.end.dateTime),
-                new Date(e.start.dateTime)
-              )
-              : 24 * 60
-          ).toString()
-        )
+        .replace("{duration}", resolveDuration(e))
     );
   } else {
     return `${summary} (${resolveDate(e.start)} - ${resolveDate(

--- a/src/event.ts
+++ b/src/event.ts
@@ -17,6 +17,12 @@ export type Event = {
   calendar: string;
 };
 
+export type EventFormatterFunction = (event: Event) => string;
+
+const customEventFormatterWrapper = (formatter: EventFormatterFunction, event:Event, defaultValue: string): string => {
+  return formatter ? formatter(event) : defaultValue;
+}
+
 const resolveDate = (d: { dateTime?: string; format?: string }) => {
   if (!d?.dateTime) {
     return "All Day";
@@ -36,7 +42,6 @@ const resolveAttendees = (e: Event, s: string) => {
 const resolveSummary = (e: Event) =>
   e.visibility === "private" ? "busy" : e.summary || "No Summary";
 
-export const formatEvent = (e: Event, format: string, includeLink: boolean): string => {
 function resolveDuration(e: Event) {
   return (e.start?.dateTime && e.end?.dateTime
       ? differenceInMinutes(
@@ -47,6 +52,12 @@ function resolveDuration(e: Event) {
   ).toString();
 }
 
+export const formatEvent = (
+  e: Event,
+  format: string,
+  includeLink: boolean,
+  customFormatter?: EventFormatterFunction
+): string => {
   const summaryText = resolveSummary(e);
   const summary =
     includeLink && e.htmlLink
@@ -84,6 +95,7 @@ function resolveDuration(e: Event) {
         )
         .replace(/{calendar}/, e.calendar)
         .replace("{duration}", resolveDuration(e))
+        .replace("{custom}", (tag) => customEventFormatterWrapper(customFormatter, e, tag))
     );
   } else {
     return `${summary} (${resolveDate(e.start)} - ${resolveDate(


### PR DESCRIPTION
⚠️  This is experimental and is here as a prompt for discussion :)

This PR adds support for custom event formatters. How does that work?

## Example usage
1. I set my format to `{start:HH:mm} {custom}`
2. I add somewhere in my graph, a `[[roam/js]]` tagged Javascript block that does something like:
```javascript
const customFormatter = e => {
  console.log(e);
  const contacts = {
   "me@example.com": "Alice Jane",
   "other@example.com": "Bob John"
  }
  // Deal with 1-1s
  if (/1-1 /.test(e.summary) && e.attendees) {
    return "[[1-1]] " + e.attendees
      .filter(attn => !attn["self"])
      .map(attn => `[[People/${contacts[attn.email] || attn.email}]]`)
      .join(", ");
  }
  // Fall back to summary as is
  return e.summary;
};

// Assign as the custom formatter!
window.roamJsGcalCustomEventFormatter = customFormatter;
```
3. When I import my calendar entries, not only will all events be logged, but I'll get this in the graph:
```
09:30 [[1-1]] [[People/Alice Jane]]
10:00 [[1-1]] [[People/Bob John]]
11:00 The original summary of this other one
```

## Explanation

A custom event formatter is a function that takes a calendar event object and returns a string from it. In order to be called, the function must be stored at `window.roamJsGcalCustomEventFormatter`, which can be done from any active Javascript block in Roam!

When the format string in the configuration contains the tag `{custom}`, then the custom formatter will be called if present, otherwise the tag will not be replaced and will come out in the event text.

## But why?
Because I spend too long every day changing the titles of my events when I import them in the graph. They have a summary that makes sense for my calendar, but not for my graph. Because I want to make sure for some events the attendees are linked to their pages, and I want to choose how I do the mapping.

## Enhancement ideas
* Perhaps change the paradigm entirely and not use `{custom}` but instead always try the custom if exists but fallback to the default formatter if the custom one returns a sentinel value
* On the other direction, double down on the current approach and allow doing things like `{custom:stuff that I write here}` and have the string `"stuff that I write here"` passed to the custom formatter.
* Error handling, what if the custom formatter throws?

## Questions
1. Is there a better way to refer to a function that is provided in another block than this trick with `window.aSpecificName`? (I'm thinking of also adding custom skip rules functions)